### PR TITLE
(maint) add a batch processing script that only requires the SHA/tag for puppet-agent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,20 @@ is contained in Jira. It does the following:
 * The Jira project name (example PUP)
 * The Jira fix version to look for (example "PUP 4.10.5")
 
+# Command line options
+
+If you like, you can specify all needed options via the command line. Usage is shown
+below
+
+```
+Usage: ruby ticketmatch.rb [options]
+    -f, --from from_rev              from git revision
+    -t, --to to_rev                  to git revision
+    -p, --project JIRA_project       JIRA project ID
+    -v, --version version_fixed_in   JIRA "fixed-in" version (in quotes for now, please)
+    -h, --help                       this message
+```
+
 # How to read the output
 
 ## The git commit section

--- a/README.md
+++ b/README.md
@@ -17,10 +17,53 @@ is contained in Jira. It does the following:
 * The Jira project name (example PUP)
 * The Jira fix version to look for (example "PUP 4.10.5")
 
-# Command line options
+# How to run ticketmatch
+
+```$ cd <git_project_directory>  ```
+
+checkout the branch you want to run against  
+
+```$ git checkout 5.0.x  ```
+
+Run ticketmatch.rb
+
+```
+$ ruby path/ticketmatch.rb  
+Enter Git From Rev: 4.10.2
+Enter Git To Rev: |master| 4.10.3
+Enter JIRA project: |PUP|
+Enter JIRA fix version: |PUP 4.10.3|
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+100  2001  100  1897  100   104   7295    399 --:--:-- --:--:-- --:--:--  7324
+** MAINT
+    e8bc39dba  correct comment in CharacterEncoding::scrub
+-- PUP-7650 (Closed)
+    a75f3c10a  Remove dead code and unnecessary call to #downcase
+    089ae6286  Fix issue related to deserialization of types
+    6f0e92737  Ensure that Loader::TypedName always uses lower-case
+-- PUP-7666 (Closed)
+    3dfa1cdb3  Update puppet version to 4.10.3
+** REVERT
+    7f663f732  Revert "Merge pull request #5738 from Iristyle/ticket/LTS-1.7/PUP-1980-fix-URI-escaping-for-UTF8"
+    7dede9921  Revert "Merge pull request #5964 from Iristyle/ticket/stable/PUP-1890-fix-duplicated-forge-query-parameter-encoding"
+
+----- Git commits in Jira -----
+COMMIT TOKENS NOT FOUND IN JIRA (OR NOT WITH FIX VERSION OF PUP 4.10.3)
+REVERT 7f663f732
+REVERT 7dede9921
+
+----- Unresolved Jira tickets not in git commits -----
+ALL ISSUES WERE FOUND IN GIT
+
+----- Unresolved Jira tickets found in git commits -----
+ALL ISSUES WERE RESOLVED IN JIRA
+```
+## Command line options/running in CI
 
 If you like, you can specify all needed options via the command line. Usage is shown
-below
+below; if you specify continuous integration mode (```--ci```), then all other arguments are
+required and will abort if not specified.
 
 ```
 Usage: ruby ticketmatch.rb [options]
@@ -28,9 +71,9 @@ Usage: ruby ticketmatch.rb [options]
     -t, --to to_rev                  to git revision
     -p, --project JIRA_project       JIRA project ID
     -v, --version version_fixed_in   JIRA "fixed-in" version (in quotes for now, please)
+    -c, --ci                         continuous integration mode (no prompting)
     -h, --help                       this message
 ```
-
 # How to read the output
 
 ## The git commit section
@@ -86,47 +129,4 @@ the proper state. Each section will print a state for the section.
 ----- Git commits in Jira -----
 ----- Unresolved Jira tickets not in git commits -----
 ----- Unresolved Jira tickets found in git commits -----
-```
-
-# How to run ticketmatch
-
-```$ cd <git_project_directory>  ```
-
-checkout the branch you want to run against  
-
-```$ git checkout 5.0.x  ```
-
-Run ticketmatch.rb
-
-```
-$ ruby path/ticketmatch.rb  
-Enter Git From Rev: 4.10.2
-Enter Git To Rev: |master| 4.10.3
-Enter JIRA project: |PUP|
-Enter JIRA fix version: |PUP 4.10.3|
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-100  2001  100  1897  100   104   7295    399 --:--:-- --:--:-- --:--:--  7324
-** MAINT
-    e8bc39dba  correct comment in CharacterEncoding::scrub
--- PUP-7650 (Closed)
-    a75f3c10a  Remove dead code and unnecessary call to #downcase
-    089ae6286  Fix issue related to deserialization of types
-    6f0e92737  Ensure that Loader::TypedName always uses lower-case
--- PUP-7666 (Closed)
-    3dfa1cdb3  Update puppet version to 4.10.3
-** REVERT
-    7f663f732  Revert "Merge pull request #5738 from Iristyle/ticket/LTS-1.7/PUP-1980-fix-URI-escaping-for-UTF8"
-    7dede9921  Revert "Merge pull request #5964 from Iristyle/ticket/stable/PUP-1890-fix-duplicated-forge-query-parameter-encoding"
-
------ Git commits in Jira -----
-COMMIT TOKENS NOT FOUND IN JIRA (OR NOT WITH FIX VERSION OF PUP 4.10.3)
-REVERT 7f663f732
-REVERT 7dede9921
-
------ Unresolved Jira tickets not in git commits -----
-ALL ISSUES WERE FOUND IN GIT
-
------ Unresolved Jira tickets found in git commits -----
-ALL ISSUES WERE RESOLVED IN JIRA
 ```

--- a/README.md
+++ b/README.md
@@ -74,6 +74,29 @@ Usage: ruby ticketmatch.rb [options]
     -c, --ci                         continuous integration mode (no prompting)
     -h, --help                       this message
 ```
+# Batch processing
+
+If you need to check all the components that comprise ```puppet-agent``` for a release, use
+```matchbatch.sh```. It requires one argument: the tag for the version of puppet-agent you
+care about. It will process ```puppet-agent``` and all components that are tagged with a SHA.
+
+Note that all component Git directories are expected to already be cloned. This will be addressed
+in a future release.
+
+## How to run matchbatch
+
+set your working directory
+
+```cd puppet-agent```
+
+get the version you care about
+
+```git checkout <the revision>```
+
+invoke matchbatch
+
+```path/matchbatch.sh <the revision>```
+
 # How to read the output
 
 ## The git commit section

--- a/matchbatch.sh
+++ b/matchbatch.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -e
+
+# get rev hashes in the form [comp]:[to_rev]
+getComponentRevMap() {
+	for componentName in $(for componentFile in $(grep -lv refs/tags configs/components/*.json); do grep -l puppetlabs ${componentFile}; done); do 
+		echo -n " $(basename ${componentName} .json):"
+		ruby -rjson -e'j = JSON.parse(STDIN.read); print j["ref"]' < ${componentName}
+	done
+}
+
+getJiraProjectIdFor() {
+	case "${1}" in
+		facter) echo FACT
+		;;
+		hiera) echo HI
+		;;
+		leatherman) echo LTH
+		;;
+		puppet) echo PUP
+		;;
+		pxp-agent) echo PCP
+		;;
+		puppet-agent) echo PA
+		;;
+		*) (>&2 echo "Error: need to add JIRA project mapping for '${1}'.")
+			exit 1
+		;;
+	esac
+}
+
+getJiraFixedInFor() {
+	case "${1}" in
+		facter) echo FACT
+		;;
+		hiera) echo HI
+		;;
+		leatherman) echo LTH
+		;;
+		puppet) echo PUP
+		;;
+		pxp-agent) echo pxp-agent
+		;;
+		puppet-agent) echo puppet-agent
+		;;
+		*) (>&2 echo "Error: need to add JIRA fixed-in version mapping for '${1}'.")
+			exit 1
+		;;
+	esac
+}
+
+decolorize() {
+#	declare input=${1:-$(</dev/stdin)}
+	read input
+	echo $input | sed -E "s/\x1B\[([0-9]{1,3}((;[0-9]{1,3})*)?)?[m|K]//g"
+}
+
+# main
+[ -z "${1}" ] && { echo "Error: must specify puppet-agent revision to start from."; exit 1; }
+[ $(basename ${PWD}) == 'puppet-agent' ] || { echo "Error: must be in puppet-agent directory"; exit 1; }
+
+# need the puppet agent revision as seed
+git checkout ${1}
+
+componentRevMap=$(getComponentRevMap)
+[ -z "${componentRevMap}" ] && { echo "Note: no components with SHAs found."; }
+
+cd ..
+
+# add puppet-agent to the list of things to check
+componentRevMap="puppet-agent:${1} ${componentRevMap}"
+
+for currentPair in ${componentRevMap}; do
+	component=$(echo -n ${currentPair} | cut -d: -f1)
+	to_rev=$(echo -n ${currentPair} | cut -d: -f2)
+
+	[ -d "${component}" ] || { echo "Error: no directory named '${component}' in ${PWD}."; exit 1; }
+	cd ${component}
+	git checkout --quiet ${to_rev}
+
+	# get current version [from_rev]
+	from_rev=$(git describe --abbrev=0 --tags)
+
+	# get fixed in version; TODO: more robust version match? [fix_ver]
+	fix_ver=$(git log -1 --no-merges --oneline -E --grep='\(packaging\) .* version' | sed -e "s/.*'\(.*\)'.*/\1/")
+
+	jiraProjectId=$(getJiraProjectIdFor "${component}")
+	jiraFixedInProject=$(getJiraFixedInFor "${component}")
+	echo
+	echo "Component: ${component}"
+	echo "<><><><><><><><><><>"
+	ruby ../ticketmatch/ticketmatch.rb --ci -f "${from_rev}" -t "${to_rev}" -p "${jiraProjectId}" -v "${jiraFixedInProject} ${fix_ver}" 2> /dev/null
+	echo "<><><><><><><><><><>"
+	cd ..
+done

--- a/ticketmatch.rb
+++ b/ticketmatch.rb
@@ -221,16 +221,20 @@ unless in_repo.chomp == "true"
   exit 1
 end
 
-if git_from_rev == nil and interactive
-  git_from_rev = ask('Enter Git From Rev: ')
-else
-  abort('ERROR: must specify a Git from revision')
+if git_from_rev == nil
+  if interactive
+    git_from_rev = ask('Enter Git From Rev: ')
+  else
+    abort('ERROR: must specify a Git from revision')
+  end
 end
 
-if git_to_rev == nil and interactive
-  git_to_rev = ask('Enter Git To Rev: ') {|q| q.default = 'master'}
-else
-  abort('ERROR: must specify a Git to revision')
+if git_to_rev == nil
+  if interactive
+    git_to_rev = ask('Enter Git To Rev: ') {|q| q.default = 'master'}
+  else
+    abort('ERROR: must specify a Git to revision')
+  end
 end
 
 # Get the log from git
@@ -252,18 +256,22 @@ git_commits.associate_reverts
 
 # collect the Jira information
 #
-if jira_project_name == nil and interactive
-  jira_project_name = ask('Enter JIRA project: ') {|q| q.default = 'PUP'}
-else
-  abort('ERROR: must specify a JIRA project ID')
+if jira_project_name == nil
+  if interactive
+    jira_project_name = ask('Enter JIRA project: ') {|q| q.default = 'PUP'}
+  else
+    abort('ERROR: must specify a JIRA project ID')
+  end
 end
 
-if jira_project_fixed_version == nil and interactive
-  jira_project_fixed_version = ask('Enter JIRA fix version: ') do |q|
-    q.default = "#{jira_project_name} #{git_to_rev}"
+if jira_project_fixed_version == nil
+  if interactive
+    jira_project_fixed_version = ask('Enter JIRA fix version: ') do |q|
+      q.default = "#{jira_project_name} #{git_to_rev}"
+    end
+  else
+    abort('ERROR: must specify a JIRA fix version')
   end
-else
-  abort('ERROR: must specify a JIRA fix version')
 end
 
 # get the list of tickets from the JIRA project that contain the fixed version
@@ -284,7 +292,7 @@ end
 
 if jira_issues['issues'].nil?
   say("JIRA returned no results for project '#{jira_project_name}' and fix version '#{jira_project_fixed_version}'")
-  exit(status=1)
+  exit 0
 end
 jira_tickets = JiraTickets.new
 jira_issues['issues'].each do |issue|
@@ -292,7 +300,7 @@ jira_issues['issues'].each do |issue|
 end
 if jira_tickets.empty?
   say("JIRA returned no results for project '#{jira_project_name}' and fix version '#{jira_project_fixed_version}'")
-  exit(status=1)
+  exit 0
 end
 
 # Print list of issues sorted, for each show sha + comment after reference


### PR DESCRIPTION
Adds a batch processing capability for all components that make up the rev of puppet-agent under test. See the README.md for further details.