### PR TITLE
(maint) Fetch any new tags from the remote in pa_matchbatch.sh

### DIFF
--- a/pa_matchbatch.sh
+++ b/pa_matchbatch.sh
@@ -154,7 +154,7 @@ cloneOrFetch() {
 	if [[ -d ${repoName} ]]; then
 		pushd ${repoName}
 		  echo "Note: fetch ${FETCH_REMOTE} for ${repoName}..."
-		  git fetch ${FETCH_REMOTE} --quiet
+		  git fetch ${FETCH_REMOTE} --tags --quiet
 		  git checkout --quiet ${targetRev}
 		popd
 	else


### PR DESCRIPTION
If you point to an already cloned repo that hasn't fetched from the
remote in a while, there's a chance that it may not have any new tags
that have been created. This causes ticketmatch to output JIRA tickets
from the releases that pushed those tags as tickets that have not been
marked with the right fix version.