### PR TITLE
(maint) Treat 'Resolved' status as done

### DIFF
--- a/ticketmatch.rb
+++ b/ticketmatch.rb
@@ -173,7 +173,7 @@ class JiraTickets
   def add_ticket(key, state, team, release_notes, rn_summary, in_git=0)
     ticket = JiraTicket.new(key, state, team, release_notes, rn_summary, in_git)
     @tickets[key] = ticket
-    unless state == 'Unresolved' || state == 'Closed'
+    unless state =~ /(Closed|Resolved)/
       @unresolved << ticket
     end
     if release_notes.nil? || (rn_summary.nil? && (release_notes != "Not Needed"))


### PR DESCRIPTION
I'm not sure if this was a typo or if I'm not understanding something here, but ticketmatch was treating Resolved puppet-agent tickets as "unresolved" for me in some manual tests -- this seems to fix things.