### PR TITLE
(maint) Fix autodetected versions in pa_matchbatch

### DIFF
--- a/pa_matchbatch.sh
+++ b/pa_matchbatch.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+# vi: set noexpandtab:
 set -e
 unset CDPATH
 
@@ -55,9 +56,9 @@ containsElement() {
 	local element="${2}"
 
 	for e in ${array}; do
-	  if [[ "${e}" == "${element}" ]]; then
-	    return 0
-	  fi
+		if [[ "${e}" == "${element}" ]]; then
+			return 0
+		fi
 	done
 
 	return 1
@@ -66,10 +67,10 @@ containsElement() {
 # get rev hashes in the form [to_rev]|[url]
 getComponentRevMap() {
 	pushd ${PUPPET_AGENT_DIR}
-	  # looking for components not pinned to a 'refs/tags' element, and of those, filtering out (keeping) the ones owned by puppetlabs
-	  for componentName in $(for componentFile in $(grep -lv refs/tags configs/components/*.json); do grep -l puppetlabs/ ${componentFile}; done); do
-		  ruby -rjson -e'j = JSON.parse(STDIN.read); printf(" %s|%s", j["ref"], j["url"])' < ${componentName}
-	  done
+		# looking for components not pinned to a 'refs/tags' element, and of those, filtering out (keeping) the ones owned by puppetlabs
+		for componentName in $(for componentFile in $(grep -lv refs/tags configs/components/*.json); do grep -l puppetlabs/ ${componentFile}; done); do
+			ruby -rjson -e'j = JSON.parse(STDIN.read); printf(" %s|%s", j["ref"], j["url"])' < ${componentName}
+		done
 	popd
 }
 
@@ -79,52 +80,52 @@ getComponentRevMap() {
 # - Otherwise look for common version files
 # - Otherwise try to find the most recent version update in the git log
 getFixVerFor() {
-    # If an overrides file was supplied, look at it for a version number first
+	# If an overrides file was supplied, look at it for a version number first
 	if [[ -f ${OVERRIDE_PATH} ]]; then
 		override=$(grep "${1}:"  ${OVERRIDE_PATH} | cut -d: -f2)
 		if [[ -n ${override} ]]; then
-		    echo ${override}
-		    return
+			echo ${override}
+			return
 		fi
 	fi
 
-    # puppet-agent has a ./VERSION file that contains only the version number
+	# puppet-agent has a ./VERSION file that contains only the version number
 	if [[ -f VERSION ]]; then
-        version=$(echo $(cat VERSION | sed -e 's/\s+//'))
-        if [[ -n ${version} ]]; then
-            echo ${version}
-            return
-        fi
+		version=$(echo $(cat VERSION | sed -e 's/\s+//'))
+		if [[ -n ${version} ]]; then
+			echo ${version}
+			return
+		fi
 	fi
 
-    # Ruby components have a version.rb in various places
-    componentName="$(basename ${PWD})"
-    if [[ $componentName = "puppet-resource_api" ]]; then
-        # The resource api has a './lib/puppet/resource_api/version.rb' which contains a `VERSION = <version>` line
-        versionFile="./lib/puppet/resource_api/version.rb"
-    else
-        # puppet has a './lib/puppet/version.rb' which contains a `PUPPETVERSION = <version>` line
-        # hiera has a './lib/hiera/version.rb' which contains a `VERSION = <version>` line
-        versionFile="./lib/${componentName}/version.rb"
-    fi
+	# Ruby components have a version.rb in various places
+	componentName="$(basename ${PWD})"
+	if [[ $componentName = "puppet-resource_api" ]]; then
+		# The resource api has a './lib/puppet/resource_api/version.rb' which contains a `VERSION = <version>` line
+		versionFile="./lib/puppet/resource_api/version.rb"
+	else
+		# puppet has a './lib/puppet/version.rb' which contains a `PUPPETVERSION = <version>` line
+		# hiera has a './lib/hiera/version.rb' which contains a `VERSION = <version>` line
+		versionFile="./lib/${componentName}/version.rb"
+	fi
 	if [[ -f ${versionFile} ]]; then
-        version=$(cat ${versionFile} | sed -nr "s/.*VERSION\s*=\s*(\"|')(.+)(\"|').*/\2/p")
-        if [[ -n ${version} ]]; then
-            echo ${version}
-            return
-        fi
-    fi
+		version=$(cat ${versionFile} | sed -nr "s/.*VERSION\s*=\s*(\"|')(.+)(\"|').*/\2/p")
+		if [[ -n ${version} ]]; then
+			echo ${version}
+			return
+		fi
+	fi
 
-    # C++ components have a version in CMakeLists.txt with a line like `project(pxp-agent VERSION <version>)`
-    if [[ -f CMakeLists.txt ]]; then
-        version=$(cat CMakeLists.txt | sed -nr "s/project\(.*VERSION\s*(.+)\)/\1/p")
-        if [[ -n ${version} ]]; then
-            echo ${version}
-            return
-        fi
-    fi
+	# C++ components have a version in CMakeLists.txt with a line like `project(pxp-agent VERSION <version>)`
+	if [[ -f CMakeLists.txt ]]; then
+		version=$(cat CMakeLists.txt | sed -nr "s/project\(.*VERSION\s*(.+)\)/\1/p")
+		if [[ -n ${version} ]]; then
+			echo ${version}
+			return
+		fi
+	fi
 
-    # Otherwise, attempt to find a version update in the git log for the component
+	# Otherwise, attempt to find a version update in the git log for the component
 	case ${1} in
 		puppet-resource_api)
 			git log -1 --no-merges --oneline --grep='Release prep' | sed -e "s/.*prep for v\(.*$\)/\1/"
@@ -207,17 +208,17 @@ cloneOrFetch() {
 
 	if [[ -d ${repoName} ]]; then
 		pushd ${repoName}
-		  echo "Fetching ${FETCH_REMOTE} for ${repoName}..."
-		  echo
-		  git fetch ${FETCH_REMOTE} --quiet
-		  git checkout --quiet ${targetRev}
+			echo "Fetching ${FETCH_REMOTE} for ${repoName}..."
+			echo
+			git fetch ${FETCH_REMOTE} --quiet
+			git checkout --quiet ${targetRev}
 		popd
 	else
 		echo "Cloning ${repoName}..."
 		echo
 		git clone --quiet ${url}
 		pushd ${repoName}
-		  git checkout --quiet ${targetRev}
+			git checkout --quiet ${targetRev}
 		popd
 	fi
 }
@@ -271,21 +272,25 @@ for currentItem in ${repoRevMap}; do
 	print_divider
 
 	cloneOrFetch "${to_rev}" "${repo_url}"
+
 	pushd ${repo}
+		# get current version [from_rev]
+		from_rev=$(git describe --abbrev=0 --tags) # | sed -e 's/^v//')
+		fix_ver=$(getFixVerFor "${public_name}")
+		jiraProjectId=$(getJiraProjectIdFor "${public_name}")
+		jiraFixedInProject=$(getJiraFixedInFor "${public_name}")
 
-	  # get current version [from_rev]
-	  from_rev=$(git describe --abbrev=0 --tags) # | sed -e 's/^v//')
-	  fix_ver=$(getFixVerFor "${public_name}")
-	  jiraProjectId=$(getJiraProjectIdFor "${public_name}")
-	  jiraFixedInProject=$(getJiraFixedInFor "${public_name}")
+		versionsUsed="${versionsUsed}\n${public_name}:${fix_ver}"
 
-	  versionsUsed="${versionsUsed}\n${public_name}:${fix_ver}"
-
-	  echo_bold "Ticketmatch results for $public_name"
-	  echo "(From tag '$from_rev' to ref '$to_rev' - JIRA fixVersion is '$(getJiraFixedInFor $public_name) $fix_ver')"
-	  echo
-	  ruby ${TICKETMATCH_PATH}/ticketmatch.rb --ci -f "${from_rev}" -t "${to_rev}" -p "${jiraProjectId}" -v "${jiraFixedInProject} ${fix_ver}" 2> /dev/null | sed 's/^/\t/g'
-	  echo
+		echo_bold "Ticketmatch results for $public_name"
+		echo "(From tag '$from_rev' to ref '$to_rev' - JIRA fixVersion is '$(getJiraFixedInFor $public_name) $fix_ver')"
+		echo
+		ruby ${TICKETMATCH_PATH}/ticketmatch.rb --ci -f "${from_rev}" -t "${to_rev}" -p "${jiraProjectId}" -v "${jiraFixedInProject} ${fix_ver}" 2> /dev/null | sed 's/^/\t/g'
+		echo
+		echo "Checking: ${foss_name}"
+		echo "from_rev: $from_rev, to_rev: $to_rev, fix_ver: $fix_ver"
+		ruby ${TICKETMATCH_PATH}/ticketmatch.rb --ci -f "${from_rev}" -t "${to_rev}" -p "${jiraProjectId}" -v "${jiraFixedInProject} ${fix_ver}" 2> /dev/null
+		echo
 	popd
 done
 


### PR DESCRIPTION
- Fixes regex for overrides files with more than one instance of the
  string 'puppet'
- Adds detection of versions based on common version files