### PR TITLE
(maint) Improve JIRA team filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ Usage: ruby ticketmatch.rb [options]
     -t, --to to_rev                  to git revision
     -p, --project JIRA_project       JIRA project ID
     -v, --version version_fixed_in   JIRA "fixed-in" version (in quotes for now, please)
+    -m, --team JIRA_team             JIRA team assigned tickets within JIRA project
     -c, --ci                         continuous integration mode (no prompting)
     -h, --help                       this message
 ```
@@ -191,7 +192,7 @@ The `R` in column 2 denotes that the git commit is a revert of the preceding com
 
 ## Jira Ticket status
 
-There are 3 sections which try to convey which of the Jira tickets are not in the proper state. Each
+There are 4 sections that try to convey which of the Jira tickets are not in the proper state. Each
 section will print a state for the section.
 
 ```


### PR DESCRIPTION
This commit reworks how the (optional) Jira team parameter is used. Previously,
we would only search for tickets in the given project where 'Team' was set to
the given value. This resulted in a lot of entries for `Git commits in Jira`,
since other teams' commits were found in git but not in the Jira query (since
they were filtered out). Now we search all tickets, but only report on the given
team's tickets when identifying unresolved tickets and tickets without release
notes.