### PR TITLE
(maint) Perforce Jira Compatibility

### DIFF
--- a/pa_matchbatch.sh
+++ b/pa_matchbatch.sh
@@ -156,7 +156,7 @@ getJiraProjectIdFor() {
 		;;
 		hiera) echo HI
 		;;
-		leatherman) echo LTH
+		leatherman) echo PA
 		;;
 		puppet) echo PUP
 		;;

--- a/ticketmatch.rb
+++ b/ticketmatch.rb
@@ -316,7 +316,7 @@ query = "project = #{jira_project_name}"
 jira_data = {
     :jql        =>  query + " AND fixVersion = \"#{jira_project_fixed_version}\" ORDER BY key",
     :maxResults => -1,
-    :fields     => ['status', 'customfield_14200', 'customfield_11100', 'customfield_10064']
+    :fields     => ['status', 'customfield_10067', 'customfield_11100', 'customfield_10064']
 }
 # Process file with Jira issues
 jira_post_data = JSON.fast_generate(jira_data)
@@ -339,7 +339,7 @@ jira_tickets = JiraTickets.new
 jira_issues['issues'].each do |issue|
   jira_tickets.add_ticket(issue['key'],
                           issue['fields']['status']['name'],
-                          issue.dig('fields', 'customfield_14200', 'value'),
+                          issue.dig('fields', 'customfield_10067', 'value'),
                           issue.dig('fields', 'customfield_11100', 'value'),
                           issue.dig('fields', 'customfield_10064'),
                           in_git=0)

--- a/ticketmatch.rb
+++ b/ticketmatch.rb
@@ -137,13 +137,12 @@ end
 #
 class JiraTicket
   attr_accessor :in_git
-  attr_reader :state, :team, :release_notes, :rn_summary, :key
+  attr_reader :state, :team, :rn_summary, :key
 
-  def initialize(key, state, team, release_notes, rn_summary, in_git=0)
+  def initialize(key, state, team, rn_summary, in_git=0)
     @key    = key
     @state  = state
     @team   = team
-    @release_notes = release_notes
     @in_git = in_git # This is a count, if its its non-zero then something was still checked in for this ticket
   end
 
@@ -171,15 +170,13 @@ class JiraTickets
     @tickets.keys
   end
 
-  def add_ticket(key, state, team, release_notes, rn_summary, in_git=0)
-    ticket = JiraTicket.new(key, state, team, release_notes, rn_summary, in_git)
+  def add_ticket(key, state, team, rn_summary, in_git=0)
+    ticket = JiraTicket.new(key, state, team, rn_summary, in_git)
     @tickets[key] = ticket
     unless state =~ /(Closed|Resolved)/
       @unresolved << ticket
     end
-    if release_notes.nil? || (rn_summary.nil? && (release_notes != "Not Needed"))
-      @missing_release_notes << ticket
-    end
+    @missing_release_notes << ticket if rn_summary.nil?
   end
 
   def empty?
@@ -316,7 +313,7 @@ query = "project = #{jira_project_name}"
 jira_data = {
     :jql        =>  query + " AND fixVersion = \"#{jira_project_fixed_version}\" ORDER BY key",
     :maxResults => -1,
-    :fields     => ['status', 'customfield_10067', 'customfield_11100', 'customfield_10064']
+    :fields     => ['status', 'customfield_10067', 'customfield_10064']
 }
 # Process file with Jira issues
 jira_post_data = JSON.fast_generate(jira_data)
@@ -340,7 +337,6 @@ jira_issues['issues'].each do |issue|
   jira_tickets.add_ticket(issue['key'],
                           issue['fields']['status']['name'],
                           issue.dig('fields', 'customfield_10067', 'value'),
-                          issue.dig('fields', 'customfield_11100', 'value'),
                           issue.dig('fields', 'customfield_10064'),
                           in_git=0)
 end

--- a/ticketmatch.rb
+++ b/ticketmatch.rb
@@ -137,13 +137,14 @@ end
 #
 class JiraTicket
   attr_accessor :in_git
-  attr_reader :state, :team, :rn_summary, :key
+  attr_reader :state, :issuetype, :team, :rn_summary, :key
 
-  def initialize(key, state, team, rn_summary, in_git=0)
-    @key    = key
-    @state  = state
-    @team   = team
-    @in_git = in_git # This is a count, if its its non-zero then something was still checked in for this ticket
+  def initialize(key, state, issuetype, team, rn_summary, in_git=0)
+    @key       = key
+    @state     = state
+    @issuetype = issuetype
+    @team      = team
+    @in_git    = in_git # This is a count, if its its non-zero then something was still checked in for this ticket
   end
 
   def to_s
@@ -170,13 +171,15 @@ class JiraTickets
     @tickets.keys
   end
 
-  def add_ticket(key, state, team, rn_summary, in_git=0)
-    ticket = JiraTicket.new(key, state, team, rn_summary, in_git)
+  def add_ticket(key, state, issuetype, team, rn_summary, in_git=0)
+    ticket = JiraTicket.new(key, state, issuetype, team, rn_summary, in_git)
     @tickets[key] = ticket
     unless state =~ /(Closed|Resolved)/
       @unresolved << ticket
     end
-    @missing_release_notes << ticket if rn_summary.nil?
+    # Epics in Perforce's Jira instance do not have a visible release note
+    # summary field, so we do not add Epics to the @missing_release_notes array
+    @missing_release_notes << ticket if rn_summary.nil? && issuetype != 'Epic'
   end
 
   def empty?
@@ -313,7 +316,7 @@ query = "project = #{jira_project_name}"
 jira_data = {
     :jql        =>  query + " AND fixVersion = \"#{jira_project_fixed_version}\" ORDER BY key",
     :maxResults => -1,
-    :fields     => ['status', 'customfield_10067', 'customfield_10064']
+    :fields     => ['status', 'issuetype', 'customfield_10067', 'customfield_10064']
 }
 # Process file with Jira issues
 jira_post_data = JSON.fast_generate(jira_data)
@@ -336,6 +339,7 @@ jira_tickets = JiraTickets.new
 jira_issues['issues'].each do |issue|
   jira_tickets.add_ticket(issue['key'],
                           issue['fields']['status']['name'],
+                          issue['fields']['issuetype']['name'],
                           issue.dig('fields', 'customfield_10067', 'value'),
                           issue.dig('fields', 'customfield_10064'),
                           in_git=0)


### PR DESCRIPTION
This PR comprises several commits that add compatibility with Perforce's Jira:

- Updates the custom field ID for teams
- Removes the "Release Notes" field, which does not exist in Perforce's Jira (note: this is different from "Release Note Summary")
- Ignores Epics without a release note summary, as that field is hidden in the Jira web interface
- Switches Leatherman work from the LTH Jira project to the PA project, as the LTH project was not migrated from Puppet's Jira instance to Perforce's.