### PR TITLE
Update ticketmatch for perforce.atlassian.net

### DIFF
--- a/pa_matchbatch.sh
+++ b/pa_matchbatch.sh
@@ -22,7 +22,26 @@ overridesFile="/tmp/version_overrides.txt"
 OVERRIDE_PATH=$(realpath ${OVERRIDE_PATH:-${overridesFile}})
 
 # read in the auth token
-AUTH_TOKEN_ARG="-a ${JIRA_AUTH_TOKEN}"
+if [[ -z "$JIRA_AUTH_TOKEN" ]]; then
+    >&2 cat <<EOF
+Error: The JIRA_AUTH_TOKEN environment variable must be set.
+
+Create a token at https://id.atlassian.com/manage-profile/security/api-tokens and run
+
+EOF
+    if [[ "$OSTYPE" == "darwin"* ]]; then
+        >&2 cat <<'EOF'
+export JIRA_AUTH_TOKEN=$(echo -n '<first>.<last>@perforce.com:<token>' | base64 --break=0)
+EOF
+    else
+        >&2 cat <<'EOF'
+export JIRA_AUTH_TOKEN=$(echo -n '<first>.<last>@perforce.com:<token>' | base64 --wrap=0)
+EOF
+    fi
+    exit 1
+else
+    AUTH_TOKEN_ARG="-a ${JIRA_AUTH_TOKEN}"
+fi
 
 echo_bold () {
     echo "$(tput bold)${1}$(tput sgr0)"

--- a/ticketmatch.rb
+++ b/ticketmatch.rb
@@ -324,7 +324,7 @@ jira_post_data = JSON.fast_generate(jira_data)
 jira_auth_header = "-H 'Authorization: Basic #{jira_auth_token}'"
 
 begin
-  jira_issues = JSON.parse(%x{curl -s -S -X POST -H 'Content-Type: application/json' #{jira_auth_header} --data '#{jira_post_data}' https://perforce.atlassian.net/rest/api/2/search})
+  jira_issues = JSON.parse(%x{curl -s -S -X POST -H 'Content-Type: application/json' #{jira_auth_header} --data '#{jira_post_data}' https://perforce.atlassian.net/rest/api/3/search})
 rescue
   say('Unable to obtain list of issues from JIRA')
   exit(status=1)

--- a/ticketmatch.rb
+++ b/ticketmatch.rb
@@ -487,4 +487,8 @@ else
   say("<%= color('ALL ISSUES CONTAIN RELEASE NOTES', GREEN) %>")
 end
 
+puts
+puts "----- All Jira tickets with fix version '#{jira_project_fixed_version}' -----"
+say(generate_url(known_jira_tickets))
+
 exit 0

--- a/ticketmatch.rb
+++ b/ticketmatch.rb
@@ -410,6 +410,12 @@ git_commits.keys.each do |ticket|
   end
 end
 
+def generate_url(keys)
+  url = "https://perforce.atlassian.net/issues/?jql=key in (#{keys.join(',')})"
+  url.gsub!(' ', '%20')
+  url.gsub!(',', '%2C')
+end
+
 puts
 puts '----- Git commits in Jira -----'
 known_jira_tickets = jira_tickets.keys
@@ -427,6 +433,7 @@ if !unknown_issues.empty?
       say("<%= color(%Q[#{ticket}], RED) %>")
     end
   end
+  say(generate_url(unknown_issues.reject { |ticket| ticket == 'REVERT' }))
 else
   say("<%= color('ALL COMMIT TOKENS WERE FOUND IN JIRA', GREEN) %>")
 end
@@ -445,6 +452,7 @@ if !unresolved_not_in_git.empty?
   unresolved_not_in_git.each do |ticket|
     say("<%= color(%Q[#{ticket}], RED) %>")
   end
+  say(generate_url(unresolved_not_in_git.map(&:key)))
 else
   say("<%= color('ALL ISSUES WERE FOUND IN GIT', GREEN) %>")
 end
@@ -456,6 +464,7 @@ if !unresolved_in_git.empty?
   unresolved_in_git.each do |ticket|
     say("<%= color(%Q[#{ticket}], RED) %>")
   end
+  say(generate_url(unresolved_in_git.map(&:key)))
 else
   say("<%= color('ALL ISSUES WERE RESOLVED IN JIRA', GREEN) %>")
 end
@@ -473,6 +482,7 @@ if !tickets_missing_release_notes.empty?
   tickets_missing_release_notes.each do |ticket|
     say("<%= color(%Q[#{ticket}], RED) %>")
   end
+  say(generate_url(tickets_missing_release_notes.map(&:key)))
 else
   say("<%= color('ALL ISSUES CONTAIN RELEASE NOTES', GREEN) %>")
 end

--- a/ticketmatch.rb
+++ b/ticketmatch.rb
@@ -177,7 +177,7 @@ class JiraTickets
   def add_ticket(key, state, issuetype, team, rn_summary, in_git=0)
     ticket = JiraTicket.new(key, state, team, rn_summary, in_git)
     @tickets[key] = ticket
-    unless state =~ /(Closed|Resolved)/
+    unless state =~ /(Closed|Resolved|Done)/
       @unresolved << ticket
     end
     # Epics in Perforce's Jira instance do not have a visible release note


### PR DESCRIPTION
* Perforce JIRA does not allow anonymous access, so check for JIRA_AUTH_TOKEN when running `pa_matchbatch.sh` and provide instructions for how to set it.

```
$ unset JIRA_AUTH_TOKEN                                                                         
$ ./pa_matchbatch.sh main             
Error: The JIRA_AUTH_TOKEN environment variable must be set.

Create a token at https://id.atlassian.com/manage-profile/security/api-tokens and run

    export JIRA_AUTH_TOKEN=$(echo -n '<first>.<last>@perforce.com:<token>' | base64 --wrap=0)
```

* Use REST v3 API instead of v2

* Subtasks have "Done" state instead of "Resolved"

* Add links for problematic tickets to make it easier to bulk edit, for example to add "Not needed" to "Release Notes Summary", assign fixVersions, etc.

* Add links for all tickets fixed in that version, to make it easy to track what's fixed and correlated that with GH releases.