### PR TITLE
(maint) Fix version parsing in private repos

### DIFF
--- a/pa_matchbatch.sh
+++ b/pa_matchbatch.sh
@@ -137,7 +137,7 @@ getFixVerFor() {
 	fi
 
 	# Ruby components have a version.rb in various places
-	componentName="$(basename ${PWD})"
+	componentName=$(stripPrivateSuffix "$(basename ${PWD})")
 	if [[ $componentName = "puppet-resource_api" ]]; then
 		# The resource api has a './lib/puppet/resource_api/version.rb' which contains a `VERSION = <version>` line
 		versionFile="./lib/puppet/resource_api/version.rb"


### PR DESCRIPTION
Previously, Ticketmatch would look for a component's version file using the name of the directory as the component name. When attempting to parse the version file of a private repository, this caused Ticketmatch to fail to find the version file and fall through to using the Git log to determine the component's version.

This commit updates Ticketmatch to strip the "-private" from a component's name before attempting to parse the version file.